### PR TITLE
added uploadCreativeAsset

### DIFF
--- a/lib/BeeswaxClient.js
+++ b/lib/BeeswaxClient.js
@@ -3,6 +3,7 @@
 var urlUtils        = require('url'),
     util            = require('util'),
     Promise         = require('bluebird'),
+    request         = require('request'),
     rp              = require('request-promise'),
     rpErrors        = require('request-promise/errors');
     
@@ -234,6 +235,105 @@ BeeswaxClient.prototype._delete = function(endpoint, idField, id, failOnNotFound
         
         return Promise.reject(resp);
     });
+};
+
+BeeswaxClient.prototype.uploadCreativeAsset = function(params){
+    var self = this;
+
+    function init(params){
+       var assetDef = {}, 
+           props = ['advertiser_id','creative_asset_name','size_in_bytes','notes','active'];
+       
+        props.forEach(function(prop){
+            if (params[prop]){
+                assetDef[prop] = params[prop];
+            }
+        });
+
+        if (!params.sourceUrl) {
+            return Promise.reject(
+                new Error('uploadCreativeAsset params requires a sourceUrl property.')
+            );
+        }
+
+
+        if (!assetDef.creative_asset_name){
+            assetDef.creative_asset_name = 
+                urlUtils.parse(params.sourceUrl).pathname.split('/').pop();
+        }
+       
+        return Promise.resolve({ req : params, assetDef : assetDef });
+    }
+
+    function getSize(data) {
+        if (data.assetDef.size_in_bytes && data.assetDef.size_in_bytes > 0){
+            return Promise.resolve(data);
+        }
+
+        return self.request('head', { url : data.req.sourceUrl }).then(function(body) {
+            if (body['content-length']){
+                data.assetDef.size_in_bytes = parseInt(body['content-length'],10);
+                return data;
+            }
+            throw new Error('Unable to detect content-length of sourceUrl: ' +
+                data.req.sourceUrl);
+        });
+    }
+
+    function createAsset(data) {
+        var opts = {
+                url: urlUtils.resolve(self.apiRoot, '/rest/creative_asset'),
+                body: data.assetDef
+            };
+        
+        return self.request('post', opts).then(function(body) {
+            data.createResponse = body;
+            return data;
+        });
+
+    }
+
+    function postFile(data){
+        return new Promise(function(resolve,reject){
+            var opts = {
+                url: urlUtils.resolve(self.apiRoot, '/rest/creative_asset/upload/' +
+                        data.createResponse.payload.id ),
+                jar : self._cookieJar
+            };
+            
+            var r = request.post(opts, function(error, response, body) {
+                if (error) {
+                    return reject(error);
+                }
+                else if (response.statusCode !== 200) { 
+                    return reject(body);
+                }
+
+                data.postFileResponse = JSON.parse(body);
+                return resolve(data);
+            });
+
+            var form = r.form();
+            form.append('creative_content',request(data.req.sourceUrl));
+        });
+    }
+    
+    function getAsset(data){
+        var opts = {
+            url: urlUtils.resolve(self.apiRoot, '/rest/creative_asset/' +
+                    data.postFileResponse.payload.id )
+        };
+        
+        return self.request('get', opts).then(function(body) {
+            return body.payload[0];
+        });
+    }
+
+    return init(params)
+        .then(getSize)
+        .then(createAsset)
+        .then(postFile)
+        .then(getAsset);
 };
 
 module.exports = BeeswaxClient;

--- a/lib/BeeswaxClient.js
+++ b/lib/BeeswaxClient.js
@@ -264,19 +264,30 @@ BeeswaxClient.prototype.uploadCreativeAsset = function(params){
        
         return Promise.resolve({ req : params, assetDef : assetDef });
     }
+    
+    function getSize(data){
+        return new Promise(function(resolve,reject){
+            var opts = {
+                url: data.req.sourceUrl
+            };
+            
+            request.head(opts, function(error, response, body) {
+                if (error) {
+                    return reject(error);
+                }
+                else if (response.statusCode !== 200) { 
+                    return reject(body);
+                }
+                
+                if (response.headers['content-length']){
+                    data.assetDef.size_in_bytes = 
+                        parseInt(response.headers['content-length'],10);
+                    return resolve(data);
+                }
 
-    function getSize(data) {
-        if (data.assetDef.size_in_bytes && data.assetDef.size_in_bytes > 0){
-            return Promise.resolve(data);
-        }
-
-        return self.request('head', { url : data.req.sourceUrl }).then(function(body) {
-            if (body['content-length']){
-                data.assetDef.size_in_bytes = parseInt(body['content-length'],10);
-                return data;
-            }
-            throw new Error('Unable to detect content-length of sourceUrl: ' +
-                data.req.sourceUrl);
+                return reject(new Error('Unable to detect content-length of sourceUrl: ' +
+                    data.req.sourceUrl));
+            });
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/cinema6/beeswax-client#readme",
   "dependencies": {
     "bluebird": "^3.4.0",
+    "request": "^2.72.0",
     "request-promise": "^3.0.0",
     "ssl-root-cas": "^1.1.10"
   },

--- a/test/spec/BeeswaxClient.ut.js
+++ b/test/spec/BeeswaxClient.ut.js
@@ -702,4 +702,39 @@ describe('BeeswaxClient', function() {
             }).done(done);
         });
     });
+
+    describe('uploadCreativeAsset', function() {
+        var beeswax , req;
+        beforeEach(function() {
+            req = {
+                sourceUrl : 'https://abc/def.jpeg'
+            };
+            beeswax = new BeeswaxClient(mockOps);
+            spyOn(beeswax, 'request');
+        });
+
+        it('rejects if there is no sourceUrl',function(done){
+            beeswax.uploadCreativeAsset({})
+            .then(done.fail, function(e){
+                expect(e.message)
+                .toEqual('uploadCreativeAsset params requires a sourceUrl property.');
+            })
+            .then(done);
+        });
+
+        it('rejects if it cannot get the content-length',function(done){
+            beeswax.request.and.callFake(function(){
+                return Promise.resolve({});
+            });
+            
+            beeswax.uploadCreativeAsset(req)
+            .then(done.fail,function(e){
+                expect(e.message).toEqual(
+                   'Unable to detect content-length of sourceUrl: https://abc/def.jpeg' 
+                );
+            })
+            .then(done);
+        });
+    });
+        
 });


### PR DESCRIPTION
Helper method to upload a creative asset (thumbnail) to beeswax.  The input is an object with only two required props:

```
advertiser_id - the beeswax advertiser id
sourceUrl - the uri for the image you want to upload
```

The method takes care of the multi-step process, and returns the response of a GET on the newly created creative_asset.

You can see that [here](http://docs.beeswax.com/docs/creativeasset-2).  Note, uploadCreativeAsset returns the 0th element of the payload array, so you get the plain object in the resolve.
