### PR TITLE
Add queryAll() for paginating through all entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # beeswax-client change log
 
+## v0.4.0
+* *[v0.4.0]*
+    * [FEATURE]: Added `queryAll` method for recursively fetching all items.
+* *[/v0.4.0]*
+
 ## v0.3.0 
 
 * *[v0.3.0]*

--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ You shouldn't need to call this method explicitly - it will be called automatica
 Send a GET request to fetch the entity with the given id.
 
 ### `beeswax.<entity>.query(body)`
-Send a GET request to fetch entities. `body` should be an object containing any fields to query by.
+Send a GET request to fetch entities. `body` should be an object containing any fields to query by. By default, Beeswax's API will fetch up to 50 records, starting with the oldest.
+
+### `beeswax.<entity>.queryAll(body)`
+Like `query()`, but recursively sends GET requests until all entities matching the query have been fetched.
 
 ### `beeswax.<entity>.create(body)`
 Send a POST request to create a new entity. `body` should be an object representing the new entity.

--- a/lib/BeeswaxClient.js
+++ b/lib/BeeswaxClient.js
@@ -62,6 +62,7 @@ function BeeswaxClient(opts) {
         self[type] = {};
         self[type].find = self._find.bind(self, cfg.endpoint, cfg.idField);
         self[type].query = self._query.bind(self, cfg.endpoint);
+        self[type].queryAll = self._queryAll.bind(self, cfg.endpoint, cfg.idField);
         self[type].create = self._create.bind(self, cfg.endpoint, cfg.idField);
         self[type].edit = self._edit.bind(self, cfg.endpoint, cfg.idField);
         self[type].delete = self._delete.bind(self, cfg.endpoint, cfg.idField);
@@ -152,6 +153,39 @@ BeeswaxClient.prototype._query = function(endpoint, body) {
     return this.request('get', opts).then(function(body) {
         return { success: true, payload: body.payload };
     });
+};
+
+// Recursively GET entities in batches until all have been fetched.
+BeeswaxClient.prototype._queryAll = function(endpoint, idField, body) {
+    var self = this,
+        results = [],
+        batchSize = 50;
+    body = body || {};
+    
+    function fetchBatch(offset) {
+        var opts = {
+            url: urlUtils.resolve(self.apiRoot, endpoint),
+            body: {}
+        };
+        for (var key in body) {
+            opts.body[key] = body[key];
+        }
+        opts.body.rows = batchSize;
+        opts.body.offset = offset;
+        opts.body.sort_by = idField;
+        
+        return self.request('get', opts).then(function(respBody) {
+            results = results.concat(respBody.payload);
+            
+            if (respBody.payload.length < batchSize) {
+                return { success: true, payload: results };
+            } else {
+                return fetchBatch(offset + batchSize);
+            }
+        });
+    }
+    
+    return fetchBatch(0);
 };
 
 // Send a POST request to create a new entity. GETs + resolves with the created entity.

--- a/test/spec/BeeswaxClient.ut.js
+++ b/test/spec/BeeswaxClient.ut.js
@@ -37,7 +37,7 @@ describe('BeeswaxClient', function() {
 
             boundFns = [];
             
-            ['_find', '_query', '_create', '_edit', '_delete'].forEach(function(method) {
+            ['_find', '_query', '_queryAll', '_create', '_edit', '_delete'].forEach(function(method) {
                 spyOn(BeeswaxClient.prototype[method], 'bind').and.callFake(function() {
                     var boundFn = Function.prototype.bind.apply(BeeswaxClient.prototype[method], arguments);
 
@@ -73,6 +73,7 @@ describe('BeeswaxClient', function() {
             expect(beeswax.advertisers).toEqual({
                 find: getBoundFn(BeeswaxClient.prototype._find, [beeswax, '/rest/advertiser', 'advertiser_id']),
                 query: getBoundFn(BeeswaxClient.prototype._query, [beeswax, '/rest/advertiser']),
+                queryAll: getBoundFn(BeeswaxClient.prototype._queryAll, [beeswax, '/rest/advertiser', 'advertiser_id']),
                 create: getBoundFn(BeeswaxClient.prototype._create, [beeswax, '/rest/advertiser', 'advertiser_id']),
                 edit: getBoundFn(BeeswaxClient.prototype._edit, [beeswax, '/rest/advertiser', 'advertiser_id']),
                 delete: getBoundFn(BeeswaxClient.prototype._delete, [beeswax, '/rest/advertiser', 'advertiser_id']),
@@ -80,6 +81,7 @@ describe('BeeswaxClient', function() {
             expect(beeswax.campaigns).toEqual({
                 find: getBoundFn(BeeswaxClient.prototype._find, [beeswax, '/rest/campaign', 'campaign_id']),
                 query: getBoundFn(BeeswaxClient.prototype._query, [beeswax, '/rest/campaign']),
+                queryAll: getBoundFn(BeeswaxClient.prototype._queryAll, [beeswax, '/rest/campaign', 'campaign_id']),
                 create: getBoundFn(BeeswaxClient.prototype._create, [beeswax, '/rest/campaign', 'campaign_id']),
                 edit: getBoundFn(BeeswaxClient.prototype._edit, [beeswax, '/rest/campaign', 'campaign_id']),
                 delete: getBoundFn(BeeswaxClient.prototype._delete, [beeswax, '/rest/campaign', 'campaign_id']),
@@ -87,6 +89,7 @@ describe('BeeswaxClient', function() {
             expect(beeswax.creatives).toEqual({
                 find: getBoundFn(BeeswaxClient.prototype._find, [beeswax, '/rest/creative', 'creative_id']),
                 query: getBoundFn(BeeswaxClient.prototype._query, [beeswax, '/rest/creative']),
+                queryAll: getBoundFn(BeeswaxClient.prototype._queryAll, [beeswax, '/rest/creative', 'creative_id']),
                 create: getBoundFn(BeeswaxClient.prototype._create, [beeswax, '/rest/creative', 'creative_id']),
                 edit: getBoundFn(BeeswaxClient.prototype._edit, [beeswax, '/rest/creative', 'creative_id']),
                 delete: getBoundFn(BeeswaxClient.prototype._delete, [beeswax, '/rest/creative', 'creative_id']),
@@ -94,6 +97,7 @@ describe('BeeswaxClient', function() {
             expect(beeswax.lineItems).toEqual({
                 find: getBoundFn(BeeswaxClient.prototype._find, [beeswax, '/rest/line_item', 'line_item_id']),
                 query: getBoundFn(BeeswaxClient.prototype._query, [beeswax, '/rest/line_item']),
+                queryAll: getBoundFn(BeeswaxClient.prototype._queryAll, [beeswax, '/rest/line_item', 'line_item_id']),
                 create: getBoundFn(BeeswaxClient.prototype._create, [beeswax, '/rest/line_item', 'line_item_id']),
                 edit: getBoundFn(BeeswaxClient.prototype._edit, [beeswax, '/rest/line_item', 'line_item_id']),
                 delete: getBoundFn(BeeswaxClient.prototype._delete, [beeswax, '/rest/line_item', 'line_item_id']),
@@ -101,6 +105,7 @@ describe('BeeswaxClient', function() {
             expect(beeswax.creativeLineItems).toEqual({
                 find: getBoundFn(BeeswaxClient.prototype._find, [beeswax, '/rest/creative_line_item', 'cli_id']),
                 query: getBoundFn(BeeswaxClient.prototype._query, [beeswax, '/rest/creative_line_item']),
+                queryAll: getBoundFn(BeeswaxClient.prototype._queryAll, [beeswax, '/rest/creative_line_item', 'cli_id']),
                 create: getBoundFn(BeeswaxClient.prototype._create, [beeswax, '/rest/creative_line_item', 'cli_id']),
                 edit: getBoundFn(BeeswaxClient.prototype._edit, [beeswax, '/rest/creative_line_item', 'cli_id']),
                 delete: getBoundFn(BeeswaxClient.prototype._delete, [beeswax, '/rest/creative_line_item', 'cli_id']),
@@ -108,6 +113,7 @@ describe('BeeswaxClient', function() {
             expect(beeswax.targetingTemplates).toEqual({
                 find: getBoundFn(BeeswaxClient.prototype._find, [beeswax, '/rest/targeting_template', 'targeting_template_id']),
                 query: getBoundFn(BeeswaxClient.prototype._query, [beeswax, '/rest/targeting_template']),
+                queryAll: getBoundFn(BeeswaxClient.prototype._queryAll, [beeswax, '/rest/targeting_template', 'targeting_template_id']),
                 create: getBoundFn(BeeswaxClient.prototype._create, [beeswax, '/rest/targeting_template', 'targeting_template_id']),
                 edit: getBoundFn(BeeswaxClient.prototype._edit, [beeswax, '/rest/targeting_template', 'targeting_template_id']),
                 delete: getBoundFn(BeeswaxClient.prototype._delete, [beeswax, '/rest/targeting_template', 'targeting_template_id']),
@@ -435,6 +441,136 @@ describe('BeeswaxClient', function() {
             }).catch(function(error) {
                 expect(error).toEqual('I GOT A PROBLEM');
                 expect(beeswax.request).toHaveBeenCalled();
+            }).done(done);
+        });
+    });
+    
+    describe('_queryAll', function() {
+        var beeswax;
+        beforeEach(function() {
+            beeswax = new BeeswaxClient(mockOps);
+            spyOn(beeswax, 'request').and.callFake(function(method, opts) {
+                var resp = { success: true, payload: [] }, i;
+                
+                if (opts.body.offset < 150) {
+                    for (i = opts.body.offset; i < opts.body.offset + 50; i++) {
+                        resp.payload.push({ id: i, name: 'item #' + i });
+                    }
+                } else {
+                    for (i = opts.body.offset; i < opts.body.offset + 25; i++) {
+                        resp.payload.push({ id: i, name: 'item #' + i });
+                    }
+                }
+                return Promise.resolve(resp);
+            });
+        });
+        
+        it('should recursively fetch items until it receives less than its batch size', function(done) {
+            beeswax._queryAll('/rest/campaign', 'campaign_id', { campaign_name: 'foobar' }).then(function(body) {
+                expect(body).toEqual({ success: true, payload: jasmine.any(Array) });
+                expect(body.payload.length).toBe(175);
+                body.payload.forEach(function(item, idx) {
+                    expect(item).toEqual({ id: idx, name: 'item #' + idx });
+                });
+                expect(beeswax.request.calls.count()).toBe(4);
+                beeswax.request.calls.allArgs().forEach(function(argArr, idx) {
+                    expect(argArr).toEqual(['get', {
+                        url: 'https://stinger.ut.api.beeswax.com/rest/campaign',
+                        body: {
+                            campaign_name: 'foobar',
+                            offset: idx * 50,
+                            rows: 50,
+                            sort_by: 'campaign_id'
+                        }
+                    }]);
+                });
+            }).catch(function(error) {
+                expect(error).not.toBeDefined();
+            }).done(done);
+        });
+        
+        it('should handle an undefined body', function(done) {
+            beeswax._queryAll('/rest/campaign', 'campaign_id').then(function(body) {
+                expect(body).toEqual({ success: true, payload: jasmine.any(Array) });
+                expect(body.payload.length).toBe(175);
+                expect(beeswax.request.calls.count()).toBe(4);
+                beeswax.request.calls.allArgs().forEach(function(argArr, idx) {
+                    expect(argArr).toEqual(['get', {
+                        url: 'https://stinger.ut.api.beeswax.com/rest/campaign',
+                        body: {
+                            offset: idx * 50,
+                            rows: 50,
+                            sort_by: 'campaign_id'
+                        }
+                    }]);
+                });
+            }).catch(function(error) {
+                expect(error).not.toBeDefined();
+            }).done(done);
+        });
+        
+        it('should override pagination params', function(done) {
+            beeswax._queryAll('/rest/campaign', 'campaign_id', { rows: 13, offset: 500, sort_by: 'campaign_name' }).then(function(body) {
+                expect(body).toEqual({ success: true, payload: jasmine.any(Array) });
+                expect(body.payload.length).toBe(175);
+                expect(beeswax.request.calls.count()).toBe(4);
+                beeswax.request.calls.allArgs().forEach(function(argArr, idx) {
+                    expect(argArr).toEqual(['get', {
+                        url: 'https://stinger.ut.api.beeswax.com/rest/campaign',
+                        body: {
+                            offset: idx * 50,
+                            rows: 50,
+                            sort_by: 'campaign_id'
+                        }
+                    }]);
+                });
+            }).catch(function(error) {
+                expect(error).not.toBeDefined();
+            }).done(done);
+        });
+        
+        it('should handle getting only a few items on the first request', function(done) {
+            beeswax.request.and.returnValue(Promise.resolve({
+                success: true,
+                payload: [{ id: 1, name: 'foo' }, { id: 2, name: 'bar' }]
+            }));
+            beeswax._queryAll('/rest/campaign', 'campaign_id', { rows: 13, offset: 500, sort_by: 'campaign_name' }).then(function(body) {
+                expect(body).toEqual({ success: true, payload: [{ id: 1, name: 'foo' }, { id: 2, name: 'bar' }] });
+                expect(beeswax.request.calls.count()).toBe(1);
+            }).catch(function(error) {
+                expect(error).not.toBeDefined();
+            }).done(done);
+        });
+        
+        it('should handle getting an empty body on the first request', function(done) {
+            beeswax.request.and.returnValue(Promise.resolve({ success: true, payload: [] }));
+            beeswax._queryAll('/rest/campaign', 'campaign_id', { rows: 13, offset: 500, sort_by: 'campaign_name' }).then(function(body) {
+                expect(body).toEqual({ success: true, payload: [] });
+                expect(beeswax.request.calls.count()).toBe(1);
+            }).catch(function(error) {
+                expect(error).not.toBeDefined();
+            }).done(done);
+        });
+        
+        it('should reject if one of the requests fails', function(done) {
+            beeswax.request.and.callFake(function(method, opts) {
+                var resp = { success: true, payload: [] }, i;
+                
+                if (opts.body.offset >= 100) {
+                    return Promise.reject('too many requests :(');
+                } else {
+                    for (i = opts.body.offset; i < opts.body.offset + 50; i++) {
+                        resp.payload.push({ id: i, name: 'item #' + i });
+                    }
+                }
+                return Promise.resolve(resp);
+            });
+
+            beeswax._queryAll('/rest/campaign', 'campaign_id', { campaign_name: 'foobar' }).then(function(body) {
+                expect(body).not.toBeDefined();
+            }).catch(function(error) {
+                expect(error).toEqual('too many requests :(');
+                expect(beeswax.request.calls.count()).toBe(3);
             }).done(done);
         });
     });


### PR DESCRIPTION
Beeswax's API will only fetch up to 50 records at a time when querying for entities.  This adds in new method, `queryAll()`, that will recursively query for entities 50 at a time until it gets less than 50 back in a response (indicating that it's fetched the last batch).  This is useful for a test script I've written in cwrx for cleaning out e2e-testing advertisers in our sandbox.
