### PR TITLE
Upload creative assets stored in Buffer objects

### DIFF
--- a/lib/BeeswaxClient.js
+++ b/lib/BeeswaxClient.js
@@ -326,7 +326,8 @@ BeeswaxClient.prototype.uploadCreativeAsset = function(params){
             
             // well, if it's a byte-array we already know it's size
             if (data.req.creativeContentBytes) {
-                return resolve(data.req.creativeContentBytes.length);
+                data.assetDef.size_in_bytes = data.req.creativeContentBytes.length;
+                return resolve(data);
             } else {
 
                 var opts = {
@@ -364,6 +365,8 @@ BeeswaxClient.prototype.uploadCreativeAsset = function(params){
         return self.request('post', opts).then(function(body) {
             data.createResponse = body;
             return data;
+        }).catch(function (err) {
+            throw err;
         });
 
     }
@@ -391,17 +394,19 @@ BeeswaxClient.prototype.uploadCreativeAsset = function(params){
             var form = r.form();
 
             var assetData = null;
+            var formOptions = null
             if (data.req.sourceUrl) {
                 assetData = request(data.req.sourceUrl);
             } else if (data.req.creativeContentBytes) {
                 assetData = data.req.creativeContentBytes;
+                formOptions = {filename: data.req.creative_asset_name};
             } else {
                 return reject(
                     new Error('Can\'t find any parameters containing creative content data')
                 );
             }
 
-            form.append('creative_content',request(data.req.sourceUrl));
+            form.append('creative_content', assetData, formOptions);
         });
     }
     

--- a/lib/BeeswaxClient.js
+++ b/lib/BeeswaxClient.js
@@ -296,9 +296,19 @@ BeeswaxClient.prototype.uploadCreativeAsset = function(params){
             }
         });
 
-        if (!params.sourceUrl) {
+        if (params.sourceUrl && params.creativeContentBytes) {
             return Promise.reject(
-                new Error('uploadCreativeAsset params requires a sourceUrl property.')
+                new Error('uploadCreativeAsset can only accept one creative content parameter' +
+                 ' at the time (either sourceUrl or creativeContentBytes).')
+            );
+        }
+
+        if (!(params.sourceUrl || params.creativeContentBytes)) {
+            return Promise.reject(
+                new Error(
+                    'uploadCreativeAsset params requires a sourceUrl' +
+                     ' or a creativeContentBytes property.'
+                )
             );
         }
 
@@ -313,27 +323,35 @@ BeeswaxClient.prototype.uploadCreativeAsset = function(params){
     
     function getSize(data){
         return new Promise(function(resolve,reject){
-            var opts = {
-                url: data.req.sourceUrl
-            };
             
-            request.head(opts, function(error, response, body) {
-                if (error) {
-                    return reject(error);
-                }
-                else if (response.statusCode !== 200) { 
-                    return reject(body);
-                }
-                
-                if (response.headers['content-length']){
-                    data.assetDef.size_in_bytes = 
-                        parseInt(response.headers['content-length'],10);
-                    return resolve(data);
-                }
+            // well, if it's a byte-array we already know it's size
+            if (data.req.creativeContentBytes) {
+                return resolve(data.req.creativeContentBytes.length);
+            } else {
 
-                return reject(new Error('Unable to detect content-length of sourceUrl: ' +
-                    data.req.sourceUrl));
-            });
+                var opts = {
+                    url: data.req.sourceUrl
+                };
+                
+                request.head(opts, function(error, response, body) {
+                    if (error) {
+                        return reject(error);
+                    }
+                    else if (response.statusCode !== 200) { 
+                        return reject(body);
+                    }
+                    
+                    if (response.headers['content-length']){
+                        data.assetDef.size_in_bytes = 
+                            parseInt(response.headers['content-length'],10);
+                        return resolve(data);
+                    }
+    
+                    return reject(new Error('Unable to detect content-length of sourceUrl: ' +
+                        data.req.sourceUrl));
+                });
+
+            }
         });
     }
 
@@ -371,6 +389,18 @@ BeeswaxClient.prototype.uploadCreativeAsset = function(params){
             });
 
             var form = r.form();
+
+            var assetData = null;
+            if (data.req.sourceUrl) {
+                assetData = request(data.req.sourceUrl);
+            } else if (data.req.creativeContentBytes) {
+                assetData = data.req.creativeContentBytes;
+            } else {
+                return reject(
+                    new Error('Can\'t find any parameters containing creative content data')
+                );
+            }
+
             form.append('creative_content',request(data.req.sourceUrl));
         });
     }

--- a/test/spec/BeeswaxClient.ut.js
+++ b/test/spec/BeeswaxClient.ut.js
@@ -873,11 +873,11 @@ describe('BeeswaxClient', function() {
             spyOn(request,'post');
         });
 
-        it('rejects if there is no sourceUrl',function(done){
+        it('rejects if there is no sourceUrl or creativeContentBytes',function(done){
             beeswax.uploadCreativeAsset({})
             .then(done.fail, function(e){
                 expect(e.message)
-                .toEqual('uploadCreativeAsset params requires a sourceUrl property.');
+                .toEqual('uploadCreativeAsset params requires a sourceUrl or a creativeContentBytes property.');
             })
             .then(done);
         });


### PR DESCRIPTION
Hi, 
This change adds an optional ability to upload creatives from a Buffer object. Before it was only possible to do so by specifying a URL to creative which is not very convenient in some cases.

Here is how the API looks like:
```
bw.uploadCreativeAsset({
    advertiser_id: <some_advertiser_id>,
    creative_asset_name: <how_to_name_a_new_asset>,
    creativeContentBytes: <buffer_object>
})
```

Thanks!